### PR TITLE
fix(thread): counting unread messages

### DIFF
--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -411,7 +411,10 @@ class Thread extends Eloquent
         }
 
         return $messages->filter(function ($message) use ($participant) {
-            return $message->updated_at->gt($participant->last_read);
+            // Only count messages the participant didn't send
+            if ($userId != $message->user_id) {
+                return $message->updated_at->gt($participant->last_read);
+            }
         });
     }
 


### PR DESCRIPTION
The userUnreadMessages() was counting messages I had sent as unread messages, but it should only count unread messages sent by somebody else.